### PR TITLE
Update fish-shell submodule, fix stream_redirect grammar rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -74,8 +74,8 @@ module.exports = grammar({
             choice($.file_redirect, $.stream_redirect),
         )),
 
-        stream_redirect: $ => token(/[012]?(>>|>|<)&[012-]/),
-        direction: $ => token(/[012&]?(>>?\??|<)/),
+        stream_redirect: $ => token(/\d*(>>|>|<)&[012-]/),
+        direction: $ => token(/(\d*|&)(>>?\??|<)/),
 
         file_redirect: $ => seq(
             field('operator', $.direction),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -116,14 +116,14 @@
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "[012]?(>>|>|<)&[012-]"
+        "value": "\\d*(>>|>|<)&[012-]"
       }
     },
     "direction": {
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "[012&]?(>>?\\??|<)"
+        "value": "(\\d*|&)(>>?\\??|<)"
       }
     },
     "file_redirect": {

--- a/src/parser.c
+++ b/src/parser.c
@@ -1031,12 +1031,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '|') ADVANCE(114);
       if (lookahead == '}') ADVANCE(186);
       if (lookahead == '~') ADVANCE(214);
-      if (('0' <= lookahead && lookahead <= '2')) ADVANCE(134);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(9);
-      if (('3' <= lookahead && lookahead <= '9')) ADVANCE(135);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(134);
       END_STATE();
     case 1:
       if (lookahead == '\n') ADVANCE(118);
@@ -1146,8 +1145,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '~') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(3)
-      if (('0' <= lookahead && lookahead <= '2')) ADVANCE(136);
-      if (('3' <= lookahead && lookahead <= '9')) ADVANCE(137);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != '^' &&
           lookahead != '}') ADVANCE(272);
@@ -1197,7 +1195,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '|') ADVANCE(114);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '2')) ADVANCE(31);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
       END_STATE();
     case 6:
       if (lookahead == '\n') ADVANCE(119);
@@ -1213,7 +1211,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '|') ADVANCE(114);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(6)
-      if (('0' <= lookahead && lookahead <= '2')) ADVANCE(31);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
       END_STATE();
     case 7:
       if (lookahead == '\n') ADVANCE(119);
@@ -1251,8 +1249,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '~') ADVANCE(214);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
-      if (('0' <= lookahead && lookahead <= '2')) ADVANCE(136);
-      if (('3' <= lookahead && lookahead <= '9')) ADVANCE(137);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != '^' &&
           lookahead != '}') ADVANCE(272);
@@ -1294,12 +1291,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '|') ADVANCE(114);
       if (lookahead == '}') ADVANCE(186);
       if (lookahead == '~') ADVANCE(214);
-      if (('0' <= lookahead && lookahead <= '2')) ADVANCE(134);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(9);
-      if (('3' <= lookahead && lookahead <= '9')) ADVANCE(135);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(134);
       END_STATE();
     case 10:
       if (lookahead == '!') ADVANCE(125);
@@ -1684,6 +1680,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 31:
       if (lookahead == '<') ADVANCE(109);
       if (lookahead == '>') ADVANCE(110);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
       END_STATE();
     case 32:
       if (lookahead == '=') ADVANCE(176);
@@ -2125,7 +2122,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(97);
       if (lookahead == '<') ADVANCE(109);
       if (lookahead == '>') ADVANCE(110);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(135);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(134);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym_integer);
@@ -2137,7 +2134,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(271);
       if (lookahead == '<') ADVANCE(109);
       if (lookahead == '>') ADVANCE(110);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(137);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(136);
       if (!sym_word_character_set_2(lookahead)) ADVANCE(272);
       END_STATE();
     case 137:

--- a/test/corpus/redirected_statement.txt
+++ b/test/corpus/redirected_statement.txt
@@ -7,6 +7,7 @@ echo ''     &>      test
 echo ''     0>      test
 echo ''     >>      test
 echo ''     1>>     test
+echo ''     11>>    test
 echo ''     >?      test
 echo ''     2>?     test
 echo ''     &>?     test
@@ -18,6 +19,13 @@ echo ''     1>>&-
 --------------------------------------------------------------------------------
 
 (program
+  (redirected_statement
+    (command
+      name: (word)
+      argument: (single_quote_string))
+    (file_redirect
+      operator: (direction)
+      destination: (word)))
   (redirected_statement
     (command
       name: (word)


### PR DESCRIPTION
After updating submodule parser failed to parse new autocompletion files introduced in this PR https://github.com/fish-shell/fish-shell/pull/8141