### PR TITLE
fix: treat "#" as a concatenation instead of comment in some cases

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -36,9 +36,13 @@ bool tree_sitter_fish_external_scanner_scan(
             lexer->lookahead == ';' ||
             lexer->lookahead == '&' ||
             lexer->lookahead == '|' ||
-            lexer->lookahead == '#' ||
             iswspace(lexer->lookahead)
         )) {
+
+            if (lexer->lookahead == '#') {
+                lexer->advance(lexer, false);
+            }
+
             lexer->result_symbol = CONCAT;
             return true;
         }

--- a/test/corpus/concatenation.txt
+++ b/test/corpus/concatenation.txt
@@ -206,3 +206,34 @@ $PATH\ ological
         (variable_name))
       (escape_sequence)
       (word))))
+
+================================================================================
+Concatenation - # in argument or command position
+================================================================================
+
+echo not#a#comment
+echo (echo 1)#notacomment
+command#with#hash
+
+--------------------------------------------------------------------------------
+
+(program
+  (command
+    (word)
+    (concatenation
+      (word)
+      (word)
+      (word)))
+  (command
+    (word)
+    (concatenation
+      (command_substitution
+        (command
+          (word)
+          (integer)))
+      (word)))
+  (command
+    (concatenation
+      (word)
+      (word)
+      (word))))


### PR DESCRIPTION
Problem: `a#command` was previously treated as a command `a` and a
comment `#command`. Also, ~hashes~ octothorpes in argument positions were treated as a
comments when they should be treated as a concatenation.

Solution: update scanner to consume `#` when scanning for CONCATR

Related issue: https://github.com/ram02z/tree-sitter-fish/issues/8