### PR TITLE
Bump cargo tree-sitter dependecy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20.9"
+tree-sitter = ">=0.22.0"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
I needed the Gleam grammar with a newer tree-sitter version that's now at 0.22.5.