### PR TITLE
fix node bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.git/
 /node_modules/
 /build/
+/target/
 tree-sitter-fish.wasm
 package-lock.json
+Cargo.lock

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # NOTE: if your language has an external scanner, add it here.
+        "src/scanner.c"
       ],
       "cflags_c": [
         "-std=c11",

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -1,0 +1,28 @@
+type BaseNode = {
+  type: string;
+  named: boolean;
+};
+
+type ChildNode = {
+  multiple: boolean;
+  required: boolean;
+  types: BaseNode[];
+};
+
+type NodeInfo =
+  | (BaseNode & {
+      subtypes: BaseNode[];
+    })
+  | (BaseNode & {
+      fields: { [name: string]: ChildNode };
+      children: ChildNode[];
+    });
+
+type Language = {
+  name: string;
+  language: unknown;
+  nodeTypeInfo: NodeInfo[];
+};
+
+declare const language: Language;
+export = language;


### PR DESCRIPTION
Fixes node bindings, which were accidently broken by regenerating `binding.gyp` in https://github.com/ram02z/tree-sitter-fish/commit/a78aef9abc395c600c38a037ac779afc7e3cc9e0

Also, add typescript types from the [tree-sitter template](https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/templates/index.d.ts)

Without this PR:

```console
$ cd "$(mktemp -d)"
$ npm add https://github.com/ram02z/tree-sitter-fish.git
$ node -e 'require("tree-sitter-fish")'
# ...
Error: dlopen(/tmp/node_modules/tree-sitter-fish/build/Release/tree_sitter_fish_binding.node, 0x0001): symbol not found in flat namespace '_tree_sitter_fish_external_scanner_create'
```
